### PR TITLE
Add open-source voice chat sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,28 @@
 # toritori
+
+Sample project demonstrating voice chat powered by open-source models.
+
+## Setup
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the voice chat loop:
+
+```bash
+python voice_chat.py
+```
+
+Press Enter to start recording, speak for a few seconds, and wait for the model to reply.  
+Say `quit` or `終了` to end the conversation.
+
+### Models
+
+- [Whisper](https://github.com/openai/whisper) for speech-to-text.
+- [DialoGPT-small](https://huggingface.co/microsoft/DialoGPT-small) for language generation.
+- [pyttsx3](https://pyttsx3.readthedocs.io/) for text-to-speech output.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+transformers
+torch
+sounddevice
+numpy
+openai-whisper
+pyttsx3

--- a/voice_chat.py
+++ b/voice_chat.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Voice chat using open-source models.
+
+This script connects speech recognition, an open-source language model,
+and text-to-speech so you can talk with your computer.
+
+Components:
+- Whisper for speech-to-text.
+- DialoGPT-small for conversational responses.
+- pyttsx3 for text-to-speech output.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+import numpy as np
+import pyttsx3
+import sounddevice as sd
+import torch
+import whisper
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def record_audio(duration: int, fs: int = 16000) -> np.ndarray:
+    """Record audio from the default microphone."""
+    print(f"Recording for {duration} seconds...")
+    audio = sd.rec(int(duration * fs), samplerate=fs, channels=1, dtype="float32")
+    sd.wait()
+    return audio.flatten()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Talk with an open-source LLM using your voice."
+    )
+    parser.add_argument(
+        "--duration",
+        type=int,
+        default=5,
+        help="Seconds to record for each user turn.",
+    )
+    args = parser.parse_args()
+
+    stt_model = whisper.load_model("base")
+    tokenizer = AutoTokenizer.from_pretrained("microsoft/DialoGPT-small")
+    lm_model = AutoModelForCausalLM.from_pretrained("microsoft/DialoGPT-small")
+    tts_engine = pyttsx3.init()
+
+    chat_history_ids: Optional[torch.Tensor] = None
+    print("Press Enter, speak, and wait for a response. Say 'quit' or '終了' to exit.")
+
+    while True:
+        input("Ready? Press Enter and start speaking...")
+
+        audio = record_audio(args.duration)
+        result = stt_model.transcribe(audio, language="ja")
+        user_text = result["text"].strip()
+        print(f"User: {user_text}")
+        if user_text.lower() in {"quit", "exit", "終了"}:
+            break
+
+        new_input_ids = tokenizer.encode(
+            user_text + tokenizer.eos_token, return_tensors="pt"
+        )
+        bot_input_ids = (
+            torch.cat([chat_history_ids, new_input_ids], dim=-1)
+            if chat_history_ids is not None
+            else new_input_ids
+        )
+        chat_history_ids = lm_model.generate(
+            bot_input_ids, max_length=1000, pad_token_id=tokenizer.eos_token_id
+        )
+        response_ids = chat_history_ids[:, bot_input_ids.shape[-1] :]
+        response = tokenizer.decode(response_ids[0], skip_special_tokens=True)
+        print(f"Bot: {response}")
+        tts_engine.say(response)
+        tts_engine.runAndWait()
+
+    print("Chat ended.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to run voice chat using Whisper for STT, DialoGPT for replies and pyttsx3 for speech
- document setup and usage instructions
- include requirements file for dependencies

## Testing
- `python -m py_compile voice_chat.py`


------
https://chatgpt.com/codex/tasks/task_e_689b21c887e483219671ee2b02a49720